### PR TITLE
fix: add auto-close UploadFileDialog when no error

### DIFF
--- a/src/components/UploadFileDialog/index.tsx
+++ b/src/components/UploadFileDialog/index.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { UploadBatchProgress } from "@/contexts/Minio/MinioContext";
 import OscarColors from "@/styles";
+import { useEffect } from "react";
 
 export default function UploadFileDialog({
   progress,
@@ -26,6 +27,17 @@ export default function UploadFileDialog({
     : 0;
 
   const failedResults = progress?.results.filter((result) => !result.success) ?? [];
+
+
+  useEffect(() => {
+    if (isOpen && progressPercent >= 100 && failedResults.length === 0) {
+      const timer = setTimeout(() => {
+        onClose();
+      }, 900); // Auto-close after 2 seconds
+
+      return () => clearTimeout(timer); // Cleanup timer 
+    }
+  }, [isOpen, progressPercent, failedResults, onClose]);
 
 
   return (


### PR DESCRIPTION
This pull request introduces an enhancement to the `UploadFileDialog` component by automatically closing the dialog when uploads are complete and there are no failed results. The most important changes are:

**Feature Enhancement:**

* Added a `useEffect` hook to `UploadFileDialog` that automatically closes the dialog shortly after all uploads are complete and successful, improving user experience.

**Dependency Updates:**

* Imported the `useEffect` hook from React to support the new auto-close functionality.