### PR TITLE
fix: handle empty buckets response and improve error handling

### DIFF
--- a/src/contexts/Minio/MinioContext.tsx
+++ b/src/contexts/Minio/MinioContext.tsx
@@ -195,22 +195,29 @@ export const MinioProvider = ({ children }: { children: React.ReactNode }) => {
 
   async function updateBuckets() {
     if (!client) return;
+    let bucketsOSCAR: Bucket_oscar[] = [];
     try {
       setBucketsAreLoading(true);
       setBucketsLoadingError(false);
+
+      bucketsOSCAR = (await getBucketsApi()) ?? [];
+
       const res = await client.send(new ListBucketsCommand({}));
       const buckets = res?.Buckets;
       if (!buckets) return;
 
-      const bucketsOSCARResponse = await getBucketsApi();
-      const bucketsOSCAR = bucketsOSCARResponse ?? [];
-      
       setBucketsOSCAR(bucketsOSCAR);
       setBuckets(buckets);
     } catch (error) {
-      console.error("Error fetching buckets:", error);
-      alert.error(`Error fetching buckets: ${errorMessage(error)}`);
-      setBucketsLoadingError(true);
+      const statusCode = (error as { $metadata?: { httpStatusCode?: number } })?.$metadata?.httpStatusCode;
+      if (statusCode === 403 && bucketsOSCAR.length === 0) {
+        setBuckets([]);
+        setBucketsOSCAR([]);
+      } else {
+        console.error("Error fetching buckets:", error);
+        alert.error(`Error fetching buckets: ${errorMessage(error)}`);
+        setBucketsLoadingError(true);
+      }
     } finally {
       setBucketsAreLoading(false);
     }


### PR DESCRIPTION
**Error Handling Improvements:**

* Added logic to specifically handle HTTP 403 errors: if a 403 error occurs and the OSCAR buckets response is empty, both `buckets` and `bucketsOSCAR` are now set to empty arrays, ensuring the UI reflects the lack of access or data.
* Improved error reporting by ensuring that other errors are logged and that the user is alerted with a descriptive message.

**Bucket Data Management:**

* Refactored the fetching of OSCAR buckets to occur before the S3 bucket fetch, storing the result in a variable for later use in error handling and state updates.
* Updated the state-setting logic to always use the latest OSCAR API response, ensuring consistency between the fetched data and the UI.