### PR TITLE
refactor: remove unnecessary state management 

### DIFF
--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
@@ -1,7 +1,6 @@
 import { Input } from "@/components/ui/input";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import { LOG_LEVEL, Service } from "@/pages/ui/services/models/service";
-import { useState } from "react";
 import {
   Select,
   SelectContent,
@@ -39,9 +38,9 @@ function ServiceGeneralTab() {
     else if (JSON.stringify(voGroups) === '[""]'){ return true}
     else {return false}
   } 
-  const [memoryUnits, setMemoryUnits] = useState<"Mi" | "Gi">(formService?.memory?.replace(/[0-9]/g, "") as "Mi" | "Gi");
-  const [memory, setMemory] = useState<string>(formService?.memory?.replace(/[a-zA-Z]/g, ""));
-
+  
+  const memoryUnits = formService?.memory?.replace(/[0-9]/g, "") as "Mi" | "Gi";
+  const memory = formService?.memory?.replace(/[a-zA-Z]/g, "");
 
   const setAllowedUsers = (users: string[]) => {
     setFormService((prev) => ({
@@ -254,7 +253,6 @@ function ServiceGeneralTab() {
               value={memory}
               label="Memory"
               onChange={(e) => {
-                setMemory(e.target.value);
                 setFormService((service: Service) => {
                   return {
                     ...service,
@@ -268,7 +266,6 @@ function ServiceGeneralTab() {
             <Select
               value={memoryUnits}
               onValueChange={(value) => {
-                setMemoryUnits(value as "Mi" | "Gi");
                 setFormService((service: Service) => {
                   return {
                     ...service,


### PR DESCRIPTION
**State management simplification:**

* Removed local `useState` hooks for `memory` and `memoryUnits`, and now derive these values directly from `formService.memory` using string manipulation.
* Removed calls to the local state setters (`setMemory`, `setMemoryUnits`) in the input and select handlers, updating only the `formService` state instead. [[1]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7L257) [[2]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7L271)

**Code cleanup:**

* Removed the now-unused `useState` import, as local state management for memory values is no longer needed.